### PR TITLE
Stabilize blueprint registration and refresh job APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+instance/
+*.db
+.env
+.env.*
+.vscode/
+.idea/
+.pytest_cache/
+.mypy_cache/

--- a/app.py
+++ b/app.py
@@ -1,0 +1,47 @@
+import os
+from typing import Optional
+
+from flask import Flask
+
+from extensions import db
+from routes.admin import admin_bp
+from routes.auth import auth_bp
+from routes.billing import billing_bp
+from routes.listings import listings_bp
+from routes.verify import verify_bp
+from services.jwt_utils import register_auth_error_handlers
+
+
+def create_app(config: Optional[dict] = None) -> Flask:
+    app = Flask(__name__)
+
+    default_config = {
+        "SQLALCHEMY_DATABASE_URI": os.environ.get("DATABASE_URL", "sqlite:///app.db"),
+        "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+        "SECRET_KEY": os.environ.get("SECRET_KEY", "dev-secret-key"),
+        "JWT_ALGORITHM": os.environ.get("JWT_ALGORITHM", "HS256"),
+    }
+    app.config.update(default_config)
+    if config:
+        app.config.update(config)
+
+    db.init_app(app)
+    register_auth_error_handlers(app)
+
+    app.register_blueprint(auth_bp)
+    app.register_blueprint(verify_bp)
+    app.register_blueprint(admin_bp)
+    app.register_blueprint(listings_bp)
+    app.register_blueprint(billing_bp)
+
+    @app.before_first_request
+    def _create_tables():
+        db.create_all()
+
+    return app
+
+
+if __name__ == "__main__":
+    application = create_app()
+    application.run(host="0.0.0.0", port=int(os.environ.get("PORT", 5000)))
+

--- a/extensions.py
+++ b/extensions.py
@@ -1,0 +1,5 @@
+from flask_sqlalchemy import SQLAlchemy
+
+# Shared SQLAlchemy instance for the application
+# Imported by modules that require database access.
+db = SQLAlchemy()

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,94 @@
+from datetime import datetime
+from typing import Any, Dict
+
+from extensions import db
+
+
+class TimestampMixin:
+    """Mixin providing created/updated timestamps."""
+
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+
+class User(db.Model, TimestampMixin):
+    __tablename__ = "users"
+
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(255), unique=True, nullable=False, index=True)
+    password_hash = db.Column(db.String(255), nullable=False)
+    role = db.Column(db.String(50), nullable=False, default="applicant")
+
+    listings = db.relationship("Listing", back_populates="employer", lazy=True)
+    applications = db.relationship("Application", back_populates="applicant", lazy=True)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "email": self.email,
+            "role": self.role,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+
+class Listing(db.Model, TimestampMixin):
+    __tablename__ = "listings"
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.Text, nullable=False)
+    company = db.Column(db.String(200), nullable=False)
+    location = db.Column(db.String(200), nullable=False)
+    category = db.Column(db.String(100), nullable=True)
+    is_remote = db.Column(db.Boolean, default=False, nullable=False)
+
+    employer_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    employer = db.relationship("User", back_populates="listings", lazy=True)
+
+    applications = db.relationship("Application", back_populates="listing", lazy=True)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "description": self.description,
+            "company": self.company,
+            "location": self.location,
+            "category": self.category,
+            "is_remote": self.is_remote,
+            "employer_id": self.employer_id,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+
+class Application(db.Model, TimestampMixin):
+    __tablename__ = "applications"
+
+    id = db.Column(db.Integer, primary_key=True)
+    applicant_name = db.Column(db.String(200), nullable=False)
+    applicant_email = db.Column(db.String(255), nullable=False)
+    resume_url = db.Column(db.String(500), nullable=True)
+    cover_letter = db.Column(db.Text, nullable=True)
+
+    listing_id = db.Column(db.Integer, db.ForeignKey("listings.id"), nullable=False)
+    applicant_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
+
+    listing = db.relationship("Listing", back_populates="applications", lazy=True)
+    applicant = db.relationship("User", back_populates="applications", lazy=True)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "applicant_name": self.applicant_name,
+            "applicant_email": self.applicant_email,
+            "resume_url": self.resume_url,
+            "cover_letter": self.cover_letter,
+            "listing_id": self.listing_id,
+            "applicant_id": self.applicant_id,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask==2.3.2
+Flask-SQLAlchemy==3.0.5
+PyJWT==2.8.0
+pytest==7.4.2

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,0 +1,2 @@
+"""Flask blueprints for the application."""
+

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -1,0 +1,21 @@
+from flask import Blueprint, jsonify
+
+from services.jwt_utils import jwt_required
+
+admin_bp = Blueprint("admin_verify", __name__)
+
+
+@admin_bp.route("/admin/health", methods=["GET"])
+@jwt_required(roles={"admin"})
+def health_check():
+    return jsonify({"status": "admin-ok"})
+
+
+@admin_bp.route("/admin/listings", methods=["GET"])
+@jwt_required(roles={"admin"})
+def list_all():
+    from models import Listing  # Imported lazily to avoid circular import
+
+    listings = [listing.to_dict() for listing in Listing.query.order_by(Listing.created_at.desc())]
+    return jsonify({"data": listings})
+

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -1,0 +1,74 @@
+from typing import Optional
+
+from flask import Blueprint, jsonify, request
+from sqlalchemy import func
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from extensions import db
+from models import User
+from services.jwt_utils import encode_token
+
+auth_bp = Blueprint("auth", __name__)
+
+
+def _normalize_email(email: str) -> str:
+    return email.strip().lower()
+
+
+@auth_bp.route("/auth/register", methods=["POST"])
+def register():
+    payload = request.get_json(silent=True) or {}
+    email: Optional[str] = payload.get("email")
+    password: Optional[str] = payload.get("password")
+    role: str = payload.get("role", "applicant")
+
+    if not email or not password:
+        return jsonify({"error": "Email and password are required"}), 400
+
+    normalized_email = _normalize_email(email)
+
+    existing = User.query.filter(func.lower(User.email) == normalized_email.lower()).first()
+    if existing:
+        return jsonify({"error": "Email already registered"}), 409
+
+    hashed_password = generate_password_hash(password)
+    user = User(email=normalized_email, password_hash=hashed_password, role=role)
+    db.session.add(user)
+    db.session.commit()
+
+    token = encode_token(user)
+    return (
+        jsonify(
+            {
+                "message": "Registration successful",
+                "token": token,
+                "user": user.to_dict(),
+            }
+        ),
+        201,
+    )
+
+
+@auth_bp.route("/auth/login", methods=["POST"])
+def login():
+    payload = request.get_json(silent=True) or {}
+    email: Optional[str] = payload.get("email")
+    password: Optional[str] = payload.get("password")
+
+    if not email or not password:
+        return jsonify({"error": "Email and password are required"}), 400
+
+    normalized_email = _normalize_email(email)
+
+    user = User.query.filter(func.lower(User.email) == normalized_email.lower()).first()
+    if not user or not check_password_hash(user.password_hash, password):
+        return jsonify({"error": "Invalid credentials"}), 401
+
+    token = encode_token(user)
+    return jsonify({"token": token, "user": user.to_dict()}), 200
+
+
+@auth_bp.route("/auth/profile", methods=["GET"])
+def profile():
+    return jsonify({"status": "ok"}), 200
+

--- a/routes/billing.py
+++ b/routes/billing.py
@@ -1,0 +1,12 @@
+from flask import Blueprint, jsonify
+
+from services.jwt_utils import jwt_required
+
+billing_bp = Blueprint("billing", __name__)
+
+
+@billing_bp.route("/billing/status", methods=["GET"])
+@jwt_required(roles={"admin"})
+def status():
+    return jsonify({"status": "billing-ok"})
+

--- a/routes/listings.py
+++ b/routes/listings.py
@@ -1,0 +1,129 @@
+from flask import Blueprint, g, jsonify, request
+from sqlalchemy import func
+
+from extensions import db
+from models import Application, Listing
+from services.jwt_utils import jwt_required
+
+listings_bp = Blueprint("listings", __name__)
+
+
+def _apply_filters(query):
+    category = request.args.get("category")
+    company = request.args.get("company")
+    location = request.args.get("location")
+    remote = request.args.get("remote")
+
+    if category:
+        query = query.filter(func.lower(Listing.category) == category.lower())
+    if company:
+        query = query.filter(func.lower(Listing.company) == company.lower())
+    if location:
+        query = query.filter(func.lower(Listing.location) == location.lower())
+    if remote is not None:
+        remote_bool = remote.lower() in {"true", "1", "yes"}
+        query = query.filter(Listing.is_remote.is_(remote_bool))
+
+    return query
+
+
+@listings_bp.route("/listings", methods=["GET"])
+def index():
+    query = Listing.query
+    query = _apply_filters(query)
+    listings = [listing.to_dict() for listing in query.order_by(Listing.created_at.desc())]
+    return jsonify({"data": listings})
+
+
+@listings_bp.route("/listings", methods=["POST"])
+@jwt_required(roles={"admin", "employer"})
+def create_listing():
+    payload = request.get_json(silent=True) or {}
+    title = payload.get("title")
+    description = payload.get("description")
+    company = payload.get("company")
+    location = payload.get("location")
+    category = payload.get("category")
+    is_remote = bool(payload.get("is_remote", False))
+
+    if not all([title, description, company, location]):
+        return jsonify({"error": "Missing required fields"}), 400
+
+    current_user = getattr(g, "current_user", None)
+
+    listing = Listing(
+        title=title,
+        description=description,
+        company=company,
+        location=location,
+        category=category,
+        is_remote=is_remote,
+        employer_id=current_user.id if current_user else None,
+    )
+
+    if listing.employer_id is None:
+        return jsonify({"error": "Employer context missing"}), 400
+
+    db.session.add(listing)
+    db.session.commit()
+
+    return jsonify({"data": listing.to_dict()}), 201
+
+
+@listings_bp.route("/listings/<int:listing_id>", methods=["GET"])
+def retrieve_listing(listing_id: int):
+    listing = Listing.query.get_or_404(listing_id)
+    return jsonify({"data": listing.to_dict()})
+
+
+@listings_bp.route("/listings/<int:listing_id>", methods=["PATCH"])
+@jwt_required(roles={"admin", "employer"})
+def update_listing(listing_id: int):
+    listing = Listing.query.get_or_404(listing_id)
+
+    current_user = getattr(g, "current_user", None)
+    if current_user and current_user.role == "employer" and listing.employer_id != current_user.id:
+        return jsonify({"error": "You do not own this listing"}), 403
+
+    payload = request.get_json(silent=True) or {}
+
+    for field in ["title", "description", "company", "location", "category"]:
+        if field in payload and payload[field] is not None:
+            setattr(listing, field, payload[field])
+
+    if "is_remote" in payload:
+        listing.is_remote = bool(payload["is_remote"])
+
+    db.session.commit()
+    return jsonify({"data": listing.to_dict()})
+
+
+@listings_bp.route("/listings/<int:listing_id>/apply", methods=["POST"])
+@jwt_required()
+def apply_to_listing(listing_id: int):
+    listing = Listing.query.get_or_404(listing_id)
+    payload = request.get_json(silent=True) or {}
+
+    applicant_name = payload.get("applicant_name")
+    applicant_email = payload.get("applicant_email")
+    resume_url = payload.get("resume_url")
+    cover_letter = payload.get("cover_letter")
+
+    if not applicant_name or not applicant_email:
+        return jsonify({"error": "Applicant name and email are required"}), 400
+
+    current_user = getattr(g, "current_user", None)
+
+    application = Application(
+        applicant_name=applicant_name,
+        applicant_email=applicant_email,
+        resume_url=resume_url,
+        cover_letter=cover_letter,
+        listing=listing,
+        applicant=current_user if current_user else None,
+    )
+    db.session.add(application)
+    db.session.commit()
+
+    return jsonify({"data": application.to_dict()}), 201
+

--- a/routes/verify.py
+++ b/routes/verify.py
@@ -1,0 +1,9 @@
+from flask import Blueprint, jsonify
+
+verify_bp = Blueprint("verify", __name__)
+
+
+@verify_bp.route("/verify/ping", methods=["GET"])
+def ping():
+    return jsonify({"status": "verified"})
+

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,2 @@
+"""Service layer helpers."""
+

--- a/services/jwt_utils.py
+++ b/services/jwt_utils.py
@@ -1,0 +1,93 @@
+from datetime import datetime, timedelta
+from functools import wraps
+from typing import Iterable, Optional
+
+import jwt
+from flask import current_app, g, jsonify, request
+from models import User
+
+
+class AuthError(Exception):
+    """Custom exception for authentication issues."""
+
+    def __init__(self, message: str, status_code: int = 401) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _get_secret() -> str:
+    secret = current_app.config.get("SECRET_KEY")
+    if not secret:
+        raise RuntimeError("SECRET_KEY must be configured for JWT support")
+    return secret
+
+
+def encode_token(user: User, expires_delta: Optional[timedelta] = None) -> str:
+    algorithm = current_app.config.get("JWT_ALGORITHM", "HS256")
+    expires = expires_delta or timedelta(hours=1)
+    payload = {
+        "sub": user.id,
+        "email": user.email,
+        "role": user.role,
+        "iat": datetime.utcnow(),
+        "exp": datetime.utcnow() + expires,
+    }
+    return jwt.encode(payload, _get_secret(), algorithm=algorithm)
+
+
+def decode_token(token: str) -> dict:
+    algorithm = current_app.config.get("JWT_ALGORITHM", "HS256")
+    return jwt.decode(token, _get_secret(), algorithms=[algorithm])
+
+
+def jwt_required(roles: Optional[Iterable[str]] = None):
+    """Decorator ensuring the presence of a valid JWT token."""
+
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            auth_header = request.headers.get("Authorization", "")
+            if not auth_header.startswith("Bearer "):
+                raise AuthError("Authorization header missing or malformed", 401)
+
+            token = auth_header.split(" ", 1)[1]
+            try:
+                payload = decode_token(token)
+            except jwt.ExpiredSignatureError as exc:
+                raise AuthError("Token has expired", 401) from exc
+            except jwt.InvalidTokenError as exc:
+                raise AuthError("Invalid token", 401) from exc
+
+            user = User.query.get(payload.get("sub"))
+            if not user:
+                raise AuthError("User not found", 401)
+
+            if roles is not None and user.role not in roles:
+                raise AuthError("Insufficient permissions", 403)
+
+            g.current_user = user
+            try:
+                return fn(*args, **kwargs)
+            finally:
+                g.pop("current_user", None)
+
+        return wrapper
+
+    return decorator
+
+
+def register_auth_error_handlers(app):
+    """Attach error handlers for authentication errors to the Flask app."""
+
+    @app.errorhandler(AuthError)
+    def handle_auth_error(error: AuthError):  # type: ignore[override]
+        response = jsonify({"error": str(error)})
+        response.status_code = getattr(error, "status_code", 401)
+        return response
+
+    @app.errorhandler(jwt.InvalidTokenError)
+    def handle_invalid_token(error):  # type: ignore[override]
+        response = jsonify({"error": "Invalid token"})
+        response.status_code = 401
+        return response
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,57 @@
+import pytest
+
+from app import create_app
+from extensions import db
+from models import User
+
+
+@pytest.fixture()
+def app():
+    app = create_app(
+        {
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+        }
+    )
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture()
+def admin_user(app):
+    from werkzeug.security import generate_password_hash
+
+    user = User(email="admin@example.com", password_hash=generate_password_hash("password"), role="admin")
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+@pytest.fixture()
+def employer_user(app):
+    from werkzeug.security import generate_password_hash
+
+    user = User(email="employer@example.com", password_hash=generate_password_hash("password"), role="employer")
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+@pytest.fixture()
+def applicant_user(app):
+    from werkzeug.security import generate_password_hash
+
+    user = User(email="applicant@example.com", password_hash=generate_password_hash("password"), role="applicant")
+    db.session.add(user)
+    db.session.commit()
+    return user
+

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,52 @@
+from werkzeug.security import check_password_hash
+
+from models import User
+
+
+def test_register_creates_user_and_hashes_password(client, app):
+    response = client.post(
+        "/auth/register",
+        json={"email": "NewUser@example.com", "password": "secure123", "role": "employer"},
+    )
+    assert response.status_code == 201
+    data = response.get_json()
+    assert "token" in data
+
+    with app.app_context():
+        user = User.query.filter_by(email="newuser@example.com").first()
+        assert user is not None
+        assert user.role == "employer"
+        assert check_password_hash(user.password_hash, "secure123")
+
+
+def test_register_rejects_duplicate_email_case_insensitive(client):
+    response = client.post(
+        "/auth/register",
+        json={"email": "duplicate@example.com", "password": "pass"},
+    )
+    assert response.status_code == 201
+
+    duplicate = client.post(
+        "/auth/register",
+        json={"email": "Duplicate@Example.com", "password": "pass"},
+    )
+    assert duplicate.status_code == 409
+
+
+def test_login_returns_token(client, employer_user):
+    response = client.post(
+        "/auth/login",
+        json={"email": "Employer@example.com", "password": "password"},
+    )
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert "token" in payload
+
+
+def test_login_rejects_wrong_password(client, employer_user):
+    response = client.post(
+        "/auth/login",
+        json={"email": "employer@example.com", "password": "wrong"},
+    )
+    assert response.status_code == 401
+

--- a/tests/test_listings.py
+++ b/tests/test_listings.py
@@ -1,0 +1,68 @@
+from services.jwt_utils import encode_token
+
+
+def auth_header_for(user):
+    token = encode_token(user)
+    return {"Authorization": f"Bearer {token}"}
+
+
+def create_listing(client, user, **overrides):
+    payload = {
+        "title": "Software Engineer",
+        "description": "Build things",
+        "company": "Tech Co",
+        "location": "Remote",
+        "category": "Engineering",
+        "is_remote": True,
+    }
+    payload.update(overrides)
+    return client.post("/listings", json=payload, headers=auth_header_for(user))
+
+
+def test_listings_get_returns_created_listing(client, employer_user):
+    create_listing(client, employer_user)
+    response = client.get("/listings")
+    assert response.status_code == 200
+    data = response.get_json()["data"]
+    assert len(data) == 1
+    assert data[0]["title"] == "Software Engineer"
+
+
+def test_create_listing_requires_employer_context(client, applicant_user):
+    response = client.post(
+        "/listings",
+        json={"title": "Role"},
+        headers=auth_header_for(applicant_user),
+    )
+    assert response.status_code == 400
+
+
+def test_create_listing_assigns_employer(client, employer_user):
+    response = create_listing(client, employer_user)
+    assert response.status_code == 201
+    listing = response.get_json()["data"]
+    assert listing["employer_id"] == employer_user.id
+
+
+def test_update_listing_allows_admin_override(client, employer_user, admin_user):
+    create_listing(client, employer_user)
+    response = client.patch(
+        "/listings/1",
+        json={"title": "Updated"},
+        headers=auth_header_for(admin_user),
+    )
+    assert response.status_code == 200
+    assert response.get_json()["data"]["title"] == "Updated"
+
+
+def test_apply_to_listing(client, employer_user, applicant_user):
+    create_listing(client, employer_user)
+    response = client.post(
+        "/listings/1/apply",
+        json={"applicant_name": "Jane", "applicant_email": "jane@example.com"},
+        headers=auth_header_for(applicant_user),
+    )
+    assert response.status_code == 201
+    data = response.get_json()["data"]
+    assert data["listing_id"] == 1
+


### PR DESCRIPTION
## Summary
- add a Flask application entry point that registers the auth, verify, admin_verify, listings, and billing blueprints exactly once
- implement JWT-backed authentication with case-insensitive email checks, hashed passwords, and supporting admin/listing/billing endpoints
- add listings CRUD/apply routes, shared models/services, and pytest coverage for auth and listing flows

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'flask' — dependencies unavailable in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe2f1567c8333810cea6c8c8de71a