### PR TITLE
Add visa document model and user verification fields

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from flask import Flask
 
-from extensions import db
+from extensions import db, migrate
 from routes.admin import admin_bp
 from routes.auth import auth_bp
 from routes.billing import billing_bp
@@ -26,6 +26,7 @@ def create_app(config: Optional[dict] = None) -> Flask:
         app.config.update(config)
 
     db.init_app(app)
+    migrate.init_app(app, db)
     register_auth_error_handlers(app)
 
     app.register_blueprint(auth_bp)
@@ -34,14 +35,9 @@ def create_app(config: Optional[dict] = None) -> Flask:
     app.register_blueprint(listings_bp)
     app.register_blueprint(billing_bp)
 
-    @app.before_first_request
-    def _create_tables():
-        db.create_all()
-
     return app
 
 
 if __name__ == "__main__":
     application = create_app()
     application.run(host="0.0.0.0", port=int(os.environ.get("PORT", 5000)))
-

--- a/extensions.py
+++ b/extensions.py
@@ -1,5 +1,7 @@
+from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 
 # Shared SQLAlchemy instance for the application
 # Imported by modules that require database access.
 db = SQLAlchemy()
+migrate = Migrate()

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,1 @@
+This directory contains Alembic database migrations.

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,45 @@
+import logging
+from logging.config import fileConfig
+
+from alembic import context
+from flask import current_app
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+logger = logging.getLogger("alembic.env")
+
+db = current_app.extensions["migrate"].db
+
+target_metadata = db.metadata
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+
+    url = config.get_main_option("sqlalchemy.url")
+    if not url:
+        url = str(current_app.extensions["migrate"].db.get_engine().url)
+        config.set_main_option("sqlalchemy.url", url)
+
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+
+    connectable = db.engine
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,18 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/migrations/versions/202401091200_add_visa_documents_and_user_verification.py
+++ b/migrations/versions/202401091200_add_visa_documents_and_user_verification.py
@@ -1,0 +1,86 @@
+"""Add visa documents table and user verification fields
+
+Revision ID: 202401091200
+Revises: 
+Create Date: 2024-01-09 12:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "202401091200"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "verification_status",
+            sa.String(length=20),
+            nullable=False,
+            server_default="unverified",
+        ),
+    )
+    op.add_column(
+        "users",
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
+
+    op.create_table(
+        "visa_documents",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("filename", sa.String(length=255), nullable=False),
+        sa.Column("file_path", sa.String(length=500), nullable=False),
+        sa.Column("file_type", sa.String(length=100), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum("pending", "approved", "rejected", name="visa_document_status"),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("reviewer_id", sa.Integer(), nullable=True),
+        sa.Column("review_note", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+            server_onupdate=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["reviewer_id"], ["users.id"]),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_visa_documents_status"), "visa_documents", ["status"], unique=False
+    )
+
+    op.alter_column(
+        "users",
+        "verification_status",
+        server_default=None,
+        existing_type=sa.String(length=20),
+    )
+    op.alter_column(
+        "users",
+        "is_active",
+        server_default=None,
+        existing_type=sa.Boolean(),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_visa_documents_status"), table_name="visa_documents")
+    op.drop_table("visa_documents")
+
+    op.drop_column("users", "is_active")
+    op.drop_column("users", "verification_status")
+
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("DROP TYPE IF EXISTS visa_document_status")

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,94 +1,13 @@
-from datetime import datetime
-from typing import Any, Dict
+from .application import Application
+from .base import TimestampMixin
+from .listing import Listing
+from .user import User
+from .visa_document import VisaDocument
 
-from extensions import db
-
-
-class TimestampMixin:
-    """Mixin providing created/updated timestamps."""
-
-    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
-    updated_at = db.Column(
-        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
-    )
-
-
-class User(db.Model, TimestampMixin):
-    __tablename__ = "users"
-
-    id = db.Column(db.Integer, primary_key=True)
-    email = db.Column(db.String(255), unique=True, nullable=False, index=True)
-    password_hash = db.Column(db.String(255), nullable=False)
-    role = db.Column(db.String(50), nullable=False, default="applicant")
-
-    listings = db.relationship("Listing", back_populates="employer", lazy=True)
-    applications = db.relationship("Application", back_populates="applicant", lazy=True)
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            "id": self.id,
-            "email": self.email,
-            "role": self.role,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
-            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
-        }
-
-
-class Listing(db.Model, TimestampMixin):
-    __tablename__ = "listings"
-
-    id = db.Column(db.Integer, primary_key=True)
-    title = db.Column(db.String(200), nullable=False)
-    description = db.Column(db.Text, nullable=False)
-    company = db.Column(db.String(200), nullable=False)
-    location = db.Column(db.String(200), nullable=False)
-    category = db.Column(db.String(100), nullable=True)
-    is_remote = db.Column(db.Boolean, default=False, nullable=False)
-
-    employer_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
-    employer = db.relationship("User", back_populates="listings", lazy=True)
-
-    applications = db.relationship("Application", back_populates="listing", lazy=True)
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            "id": self.id,
-            "title": self.title,
-            "description": self.description,
-            "company": self.company,
-            "location": self.location,
-            "category": self.category,
-            "is_remote": self.is_remote,
-            "employer_id": self.employer_id,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
-            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
-        }
-
-
-class Application(db.Model, TimestampMixin):
-    __tablename__ = "applications"
-
-    id = db.Column(db.Integer, primary_key=True)
-    applicant_name = db.Column(db.String(200), nullable=False)
-    applicant_email = db.Column(db.String(255), nullable=False)
-    resume_url = db.Column(db.String(500), nullable=True)
-    cover_letter = db.Column(db.Text, nullable=True)
-
-    listing_id = db.Column(db.Integer, db.ForeignKey("listings.id"), nullable=False)
-    applicant_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
-
-    listing = db.relationship("Listing", back_populates="applications", lazy=True)
-    applicant = db.relationship("User", back_populates="applications", lazy=True)
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            "id": self.id,
-            "applicant_name": self.applicant_name,
-            "applicant_email": self.applicant_email,
-            "resume_url": self.resume_url,
-            "cover_letter": self.cover_letter,
-            "listing_id": self.listing_id,
-            "applicant_id": self.applicant_id,
-            "created_at": self.created_at.isoformat() if self.created_at else None,
-            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
-        }
+__all__ = [
+    "TimestampMixin",
+    "User",
+    "Listing",
+    "Application",
+    "VisaDocument",
+]

--- a/models/application.py
+++ b/models/application.py
@@ -1,0 +1,33 @@
+from typing import Any, Dict
+
+from extensions import db
+from .base import TimestampMixin
+
+
+class Application(db.Model, TimestampMixin):
+    __tablename__ = "applications"
+
+    id = db.Column(db.Integer, primary_key=True)
+    applicant_name = db.Column(db.String(200), nullable=False)
+    applicant_email = db.Column(db.String(255), nullable=False)
+    resume_url = db.Column(db.String(500), nullable=True)
+    cover_letter = db.Column(db.Text, nullable=True)
+
+    listing_id = db.Column(db.Integer, db.ForeignKey("listings.id"), nullable=False)
+    applicant_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
+
+    listing = db.relationship("Listing", back_populates="applications", lazy=True)
+    applicant = db.relationship("User", back_populates="applications", lazy=True)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "applicant_name": self.applicant_name,
+            "applicant_email": self.applicant_email,
+            "resume_url": self.resume_url,
+            "cover_letter": self.cover_letter,
+            "listing_id": self.listing_id,
+            "applicant_id": self.applicant_id,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/models/base.py
+++ b/models/base.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+
+from extensions import db
+
+
+class TimestampMixin:
+    """Mixin providing created/updated timestamps."""
+
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = db.Column(
+        db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )

--- a/models/listing.py
+++ b/models/listing.py
@@ -1,0 +1,35 @@
+from typing import Any, Dict
+
+from extensions import db
+from .base import TimestampMixin
+
+
+class Listing(db.Model, TimestampMixin):
+    __tablename__ = "listings"
+
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.Text, nullable=False)
+    company = db.Column(db.String(200), nullable=False)
+    location = db.Column(db.String(200), nullable=False)
+    category = db.Column(db.String(100), nullable=True)
+    is_remote = db.Column(db.Boolean, default=False, nullable=False)
+
+    employer_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    employer = db.relationship("User", back_populates="listings", lazy=True)
+
+    applications = db.relationship("Application", back_populates="listing", lazy=True)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "description": self.description,
+            "company": self.company,
+            "location": self.location,
+            "category": self.category,
+            "is_remote": self.is_remote,
+            "employer_id": self.employer_id,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/models/user.py
+++ b/models/user.py
@@ -1,0 +1,51 @@
+from typing import Any, Dict, Optional
+
+from extensions import db
+from .base import TimestampMixin
+
+
+class User(db.Model, TimestampMixin):
+    __tablename__ = "users"
+
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(255), unique=True, nullable=False, index=True)
+    password_hash = db.Column(db.String(255), nullable=False)
+    role = db.Column(db.String(50), nullable=False, default="applicant")
+    verification_status = db.Column(db.String(20), nullable=False, default="unverified")
+    is_active = db.Column(db.Boolean, nullable=False, default=True)
+
+    listings = db.relationship("Listing", back_populates="employer", lazy=True)
+    applications = db.relationship("Application", back_populates="applicant", lazy=True)
+    visa_documents = db.relationship(
+        "VisaDocument", back_populates="user", lazy=True, cascade="all, delete-orphan"
+    )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "email": self.email,
+            "role": self.role,
+            "verification_status": self.verification_status,
+            "is_active": self.is_active,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+    def mark_verified(self) -> None:
+        """Mark the user as verified and active."""
+
+        self.verification_status = "verified"
+        self.is_active = True
+
+    def mark_unverified(self, note: Optional[str] = None) -> None:
+        """Mark the user as unverified and optionally log a note.
+
+        Args:
+            note: Optional note about the unverification reason (unused placeholder).
+        """
+
+        self.verification_status = "unverified"
+        self.is_active = False
+        if note:
+            # Placeholder for future logging or auditing integrations.
+            setattr(self, "_last_unverification_note", note)

--- a/models/visa_document.py
+++ b/models/visa_document.py
@@ -1,0 +1,53 @@
+from typing import Any, Dict, Optional
+
+from extensions import db
+from .base import TimestampMixin
+
+
+class VisaDocument(db.Model, TimestampMixin):
+    __tablename__ = "visa_documents"
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+    filename = db.Column(db.String(255), nullable=False)
+    file_path = db.Column(db.String(500), nullable=False)
+    file_type = db.Column(db.String(100), nullable=False)
+    status = db.Column(
+        db.Enum("pending", "approved", "rejected", name="visa_document_status"),
+        nullable=False,
+        default="pending",
+    )
+    reviewer_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=True)
+    review_note = db.Column(db.Text, nullable=True)
+
+    user = db.relationship(
+        "User", foreign_keys=[user_id], back_populates="visa_documents", lazy=True
+    )
+    reviewer = db.relationship("User", foreign_keys=[reviewer_id], lazy=True)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "filename": self.filename,
+            "file_path": self.file_path,
+            "file_type": self.file_type,
+            "status": self.status,
+            "reviewer_id": self.reviewer_id,
+            "review_note": self.review_note,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+    @property
+    def is_pending(self) -> bool:
+        return self.status == "pending"
+
+    def mark_reviewed(
+        self, status: str, reviewer_id: Optional[int] = None, note: Optional[str] = None
+    ) -> None:
+        if status not in {"approved", "rejected"}:
+            raise ValueError("Status must be 'approved' or 'rejected'")
+        self.status = status
+        self.reviewer_id = reviewer_id
+        self.review_note = note

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask==2.3.2
+Flask-Migrate==4.0.4
 Flask-SQLAlchemy==3.0.5
 PyJWT==2.8.0
 pytest==7.4.2


### PR DESCRIPTION
## Summary
- integrate Flask-Migrate, restructure models into separate modules, and expose a shared timestamp mixin
- add a VisaDocument model with review helpers plus relationships to users
- generate an Alembic migration adding visa_documents and the new user verification columns

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'flask')*
- python -m flask db upgrade *(fails: No module named flask)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe911464c8333bc50cf61617be156