### PR TITLE
Add verification document upload workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ instance/
 .idea/
 .pytest_cache/
 .mypy_cache/
+uploads/

--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from flask import Flask
 
+from config import ALLOWED_UPLOAD_TYPES, MAX_UPLOAD_SIZE, UPLOAD_DIR
 from extensions import db, migrate
 from routes.admin import admin_bp
 from routes.auth import auth_bp
@@ -20,6 +21,9 @@ def create_app(config: Optional[dict] = None) -> Flask:
         "SQLALCHEMY_TRACK_MODIFICATIONS": False,
         "SECRET_KEY": os.environ.get("SECRET_KEY", "dev-secret-key"),
         "JWT_ALGORITHM": os.environ.get("JWT_ALGORITHM", "HS256"),
+        "UPLOAD_DIR": os.environ.get("UPLOAD_DIR", UPLOAD_DIR),
+        "MAX_UPLOAD_SIZE": MAX_UPLOAD_SIZE,
+        "ALLOWED_UPLOAD_TYPES": ALLOWED_UPLOAD_TYPES,
     }
     app.config.update(default_config)
     if config:
@@ -28,6 +32,8 @@ def create_app(config: Optional[dict] = None) -> Flask:
     db.init_app(app)
     migrate.init_app(app, db)
     register_auth_error_handlers(app)
+
+    os.makedirs(app.config["UPLOAD_DIR"], exist_ok=True)
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(verify_bp)

--- a/config.py
+++ b/config.py
@@ -1,0 +1,20 @@
+"""Application configuration defaults."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+BASE_DIR = Path(__file__).parent.resolve()
+DEFAULT_UPLOAD_DIR = os.getenv("UPLOAD_DIR", str(BASE_DIR / "uploads"))
+
+MAX_UPLOAD_SIZE = int(os.getenv("MAX_UPLOAD_SIZE", 10 * 1024 * 1024))
+ALLOWED_UPLOAD_TYPES = [
+    mime.strip()
+    for mime in os.getenv(
+        "ALLOWED_UPLOAD_TYPES", "image/jpeg,image/png,application/pdf"
+    ).split(",")
+    if mime.strip()
+]
+
+UPLOAD_DIR = DEFAULT_UPLOAD_DIR

--- a/routes/verify.py
+++ b/routes/verify.py
@@ -1,9 +1,163 @@
-from flask import Blueprint, jsonify
+"""Routes for managing user verification documents."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+from flask import (
+    Blueprint,
+    abort,
+    current_app,
+    g,
+    jsonify,
+    request,
+    send_file,
+)
+
+from extensions import db
+from models import User, VisaDocument
+from services.jwt_utils import jwt_required
+from storage.local_storage import LocalStorage
 
 verify_bp = Blueprint("verify", __name__)
 
 
-@verify_bp.route("/verify/ping", methods=["GET"])
-def ping():
-    return jsonify({"status": "verified"})
+def _get_storage() -> LocalStorage:
+    upload_dir = current_app.config["UPLOAD_DIR"]
+    return LocalStorage(upload_dir)
 
+
+def _validate_file(file_storage) -> None:
+    if file_storage is None:
+        abort(400, description="Missing document upload")
+
+    allowed_types = set(current_app.config.get("ALLOWED_UPLOAD_TYPES", []))
+    if file_storage.mimetype not in allowed_types:
+        abort(400, description="Unsupported file type")
+
+    max_size = current_app.config.get("MAX_UPLOAD_SIZE")
+    content_length = request.content_length
+    if max_size and content_length and content_length > max_size:
+        abort(413, description="Uploaded file exceeds maximum size")
+
+    # Ensure stream size is within limits when content_length is absent.
+    if max_size:
+        stream = file_storage.stream
+        current_pos = stream.tell()
+        stream.seek(0, os.SEEK_END)
+        size = stream.tell()
+        stream.seek(0)
+        if size > max_size:
+            abort(413, description="Uploaded file exceeds maximum size")
+        stream.seek(current_pos)
+
+
+@verify_bp.route("/verify/upload", methods=["POST"])
+@jwt_required()
+def upload_document() -> Any:
+    file_storage = request.files.get("document")
+    _validate_file(file_storage)
+
+    waiver_flag = request.form.get("waiver", "false").lower() in {
+        "true",
+        "1",
+        "yes",
+    }
+
+    storage = _get_storage()
+    filename, file_path = storage.save(file_storage)
+
+    user: User = g.current_user
+    document = VisaDocument(
+        user_id=user.id,
+        filename=filename,
+        file_path=file_path,
+        file_type=file_storage.mimetype,
+        status="pending",
+    )
+    user.verification_status = "pending"
+
+    db.session.add(document)
+    db.session.commit()
+
+    response: Dict[str, Any] = {
+        "message": "Document uploaded successfully",
+        "document": document.to_dict(),
+        "waiver": waiver_flag,
+        "verification_status": user.verification_status,
+    }
+    return jsonify(response), 201
+
+
+@verify_bp.route("/verify/status", methods=["GET"])
+@jwt_required()
+def verification_status() -> Any:
+    user: User = g.current_user
+    latest_document = (
+        VisaDocument.query.filter_by(user_id=user.id)
+        .order_by(VisaDocument.created_at.desc())
+        .first()
+    )
+    response: Dict[str, Any] = {
+        "verification_status": user.verification_status,
+        "latest_document": latest_document.to_dict() if latest_document else None,
+    }
+    return jsonify(response)
+
+
+@verify_bp.route("/verify/doc/<int:document_id>", methods=["GET"])
+@jwt_required(roles=["admin"])
+def get_document(document_id: int):
+    document = VisaDocument.query.get_or_404(document_id)
+    if not os.path.exists(document.file_path):
+        abort(404, description="Stored file not found")
+
+    return send_file(
+        document.file_path,
+        as_attachment=True,
+        download_name=document.filename,
+    )
+
+
+@verify_bp.route("/verify/<int:document_id>/approve", methods=["POST"])
+@jwt_required(roles=["admin"])
+def approve_document(document_id: int):
+    document = VisaDocument.query.get_or_404(document_id)
+    admin_user: User = g.current_user
+
+    document.mark_reviewed("approved", reviewer_id=admin_user.id)
+    document.user.verification_status = "verified"
+
+    db.session.commit()
+
+    response = {
+        "message": "Document approved",
+        "document": document.to_dict(),
+        "verification_status": document.user.verification_status,
+    }
+    return jsonify(response)
+
+
+@verify_bp.route("/verify/<int:document_id>/reject", methods=["POST"])
+@jwt_required(roles=["admin"])
+def reject_document(document_id: int):
+    document = VisaDocument.query.get_or_404(document_id)
+    admin_user: User = g.current_user
+
+    payload = request.get_json(silent=True) or {}
+    review_note = payload.get("review_note")
+    if not review_note:
+        abort(400, description="review_note is required for rejection")
+
+    document.mark_reviewed("rejected", reviewer_id=admin_user.id, note=review_note)
+    document.user.verification_status = "rejected"
+
+    db.session.commit()
+
+    response = {
+        "message": "Document rejected",
+        "document": document.to_dict(),
+        "verification_status": document.user.verification_status,
+    }
+    return jsonify(response)

--- a/storage/__init__.py
+++ b/storage/__init__.py
@@ -1,0 +1,5 @@
+"""Storage backends for file uploads."""
+
+from .local_storage import LocalStorage
+
+__all__ = ["LocalStorage"]

--- a/storage/abstract_storage.py
+++ b/storage/abstract_storage.py
@@ -1,0 +1,18 @@
+"""Abstract storage backend definitions for file uploads."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Tuple
+
+from werkzeug.datastructures import FileStorage
+
+
+class AbstractStorage(ABC):
+    """Interface for storage backends used by the application."""
+
+    @abstractmethod
+    def save(self, file_storage: FileStorage) -> Tuple[str, str]:
+        """Persist a file and return a tuple of (filename, file_path)."""
+
+        raise NotImplementedError

--- a/storage/local_storage.py
+++ b/storage/local_storage.py
@@ -1,0 +1,33 @@
+"""Local filesystem storage backend for uploads."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Tuple
+
+from werkzeug.datastructures import FileStorage
+from werkzeug.utils import secure_filename
+
+from .abstract_storage import AbstractStorage
+
+
+class LocalStorage(AbstractStorage):
+    """Store uploaded files on the local filesystem."""
+
+    def __init__(self, upload_dir: str) -> None:
+        self.upload_dir = upload_dir
+
+    def save(self, file_storage: FileStorage) -> Tuple[str, str]:
+        if not file_storage or not file_storage.filename:
+            raise ValueError("A valid file must be provided")
+
+        original_name = secure_filename(file_storage.filename)
+        name, ext = os.path.splitext(original_name)
+        unique_name = f"{name or 'upload'}_{uuid.uuid4().hex}{ext}"
+
+        os.makedirs(self.upload_dir, exist_ok=True)
+        file_path = os.path.join(self.upload_dir, unique_name)
+        file_storage.save(file_path)
+
+        return unique_name, file_path


### PR DESCRIPTION
## Summary
- add configuration defaults for upload size and allowed file types and ensure the upload directory exists on startup
- implement a local storage backend for saving uploaded verification documents securely
- expand the verification blueprint with upload, status, admin review, and document retrieval routes

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68dbf04e065c83338d3a5e735220c757